### PR TITLE
feat: Remove personal invite support

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -279,24 +279,6 @@ def reset():
   )
 
 
-@application.route('/i/<invite>/')
-def invite(invite):
-  if util.user_agent()['is']['desktop']:
-    util.track_event_to_piwik('account.invite', 'redirect', 'desktop', 1)
-    return flask.redirect('%s/auth/#invite/%s' % (config.WEBAPP_URL, invite))
-
-  if util.user_agent()['is']['ios']:
-    util.track_event_to_piwik('account.invite', 'redirect', 'ios', 1)
-    return flask.redirect(config.DOWNLOAD_IOS_URL)
-
-  if util.user_agent()['is']['android']:
-    util.track_event_to_piwik('account.invite', 'redirect', 'android', 1)
-    return flask.redirect('%s&referrer=invite-%s' % (config.DOWNLOAD_ANDROID_URL, invite))
-
-  util.track_event_to_piwik('account.invite', 'redirect', 'other', 1)
-  return flask.redirect(config.WIRE_DOWNLOAD_URL)
-
-
 @application.route('/t/<team_code>')
 @application.route('/t/<team_code>/')
 def team_invite(team_code):


### PR DESCRIPTION
Stats on Innocraft showed a single request in October. Feature was removed from all clients by May 2018.

https://github.com/wireapp/wire-web-packages/pull/1239
https://github.com/wireapp/wire-webapp/pull/4924