### PR TITLE
feat: Remove obsolete team invitation redirect

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -273,12 +273,6 @@ def reset():
   )
 
 
-@application.route('/t/<team_code>')
-@application.route('/t/<team_code>/')
-def team_invite(team_code):
-  return flask.redirect('%s/join/?team-code=%s' % (config.TEAMS_URL, team_code))
-
-
 ###############################################################################
 # Delete
 ###############################################################################


### PR DESCRIPTION
https://github.com/wearezeta/backend-issues/issues/748

The change to directly point the link in team member invite links to team settings instead of needing a redirect from the account pages has been deployed to `prod`.

Thus this route can be removed.

**THE END**