### PR TITLE
feat: Allow only /forgot/ for crawlers

### DIFF
--- a/app/static/robots.txt
+++ b/app/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Allow: /
+Disallow: /
+Allow: /forgot/


### PR DESCRIPTION
The only thing that could be accessible from Google should be the /forgot/ page

Related: https://github.com/wireapp/wire-gatsby/issues/1031