### PR TITLE
chore: Docker use jessie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM node:10-jessie
- # For some extra dependencies...
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        curl git bash \
-    && curl -sLo /tmp/dumb-init.deb \
-		https://github.com/Yelp/dumb-init/releases/download/v1.0.2/dumb-init_1.0.2_amd64.deb \
-	&& dpkg -i /tmp/dumb-init.deb \
-	&& rm /tmp/dumb-init.deb \
-	&& apt-get clean
+# For some extra dependencies...
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl git bash && \
+  curl -sLo /tmp/dumb-init.deb https://github.com/Yelp/dumb-init/releases/download/v1.0.2/dumb-init_1.0.2_amd64.deb && \
+  dpkg -i /tmp/dumb-init.deb && \
+  rm /tmp/dumb-init.deb && \
+  apt-get clean
 
 COPY dist/ .
 COPY yarn.lock .


### PR DESCRIPTION
It's a bit annoying given that the image size is now 20x but due to 
https://github.com/nodejs/node/issues/15780#issuecomment-425930255
https://github.com/gliderlabs/docker-alpine/blob/master/docs/caveats.md
https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html
we're better off doing this until we find a better solution