### PR TITLE
chore: Only allow tag deployments on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ deploy:
     env: wire-account-prod
     bucket_name: wire-account-builds
     on:
-      tags: true
       branch: master
       condition: $DISTRIBUTION = wire
+      tags: true
 
   - provider: elasticbeanstalk
     skip_cleanup: true
@@ -75,6 +75,7 @@ deploy:
     env: wire-account-staging
     bucket_name: wire-account-builds
     on:
-      repo: wireapp/wire-account
       branch: staging
       condition: $DISTRIBUTION = wire
+      repo: wireapp/wire-account
+      tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ deploy:
     bucket_name: wire-account-builds
     on:
       tags: true
+      branch: master
       condition: $DISTRIBUTION = wire
 
   - provider: elasticbeanstalk


### PR DESCRIPTION
This will prevent to deploy the application with a production configuration when merging back from master to staging after a release.

Note:
- A tag causes the application to load the production configuration