### PR TITLE
chore: Add link to explain why Helm chart update job might throw an error

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -193,6 +193,7 @@ jobs:
     needs: test_build_deploy
 
     steps:
+      # INFO: https://github.com/wireapp/wire-webapp/blob/062ae4e1c23fa0b33dafae9cc0acf9a94fa8ad1a/.github/workflows/test_build_deploy.yml#L351-L356
       - name: Obtaining release information artifact
         id: release-info-artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This is a port from the webapp repository, since that part of logic is the same.

*originating from: https://github.com/wireapp/wire-webapp/pull/11242*