### PR TITLE
chore(wire-server): Include changelog entry

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -223,6 +223,8 @@ jobs:
         run: |
           sed --in-place --expression="s/  tag: .*/  tag: \"${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}\"/" ./charts/account-pages/values.yaml
           git add ./charts/account-pages/values.yaml
+          echo "Upgrade account-pages version to ${{ fromJSON(steps.release-info-file.outputs.releaseInfo).imageTag }}" > ./changelog.d/0-release-notes/account-pages-upgrade
+          git add ./changelog.d/0-release-notes/account-pages-upgrade
           echo "::set-output name=releaseUrl::${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${{ fromJSON(steps.release-info-file.outputs.releaseInfo).releaseName }}"
 
       - name: Creating Pull Request


### PR DESCRIPTION
We recently added a changelog process on wire-server. This adds a file on the automatic PRs with a changelog description that is then picked up with the rest of our current process. This is for the helm charts of the account pages, also currently located inside the wire-server repo. These are used as the defaults for on-premise installations.

See also https://github.com/wireapp/wire-team-settings/pull/5413 and https://github.com/wireapp/wire-webapp/pull/12022