### PR TITLE
runfix: Do not automatically add extra url params to wire links [SQSERVICES-1428, SQSERVICES-1415]

### DIFF
--- a/src/script/component/OpenWireButtons.tsx
+++ b/src/script/component/OpenWireButtons.tsx
@@ -19,7 +19,6 @@
 
 import React from 'react';
 import {Runtime} from '@wireapp/commons';
-import {pathWithParams} from '@wireapp/commons/src/main/util/UrlUtil';
 import {ButtonLink} from '@wireapp/react-ui-kit';
 import {DirectDownloadButton} from 'script/component/DirectDownloadButton';
 import {WebsiteDownloadButton} from 'script/component/WebsiteDownloadButton';
@@ -44,21 +43,13 @@ export const OpenWireButtons: React.FC<OpenWireProps> = ({paths, translate, uieN
   return (
     <>
       {canJoinInApp && (
-        <ButtonLink
-          href={pathWithParams(`${WIRE_APP_SCHEME}${paths.app}`)}
-          style={{marginRight: 16}}
-          data-uie-name={`${uieName}-app`}
-        >
+        <ButtonLink href={`${WIRE_APP_SCHEME}${paths.app}`} style={{marginRight: 16}} data-uie-name={`${uieName}-app`}>
           {translate('openWithApp')}
         </ButtonLink>
       )}
 
       {canJoinInBrowser && (
-        <ButtonLink
-          href={pathWithParams(`${WEBAPP_URL}${paths.webapp}`)}
-          style={{marginRight: 16}}
-          data-uie-name={`${uieName}-webapp`}
-        >
+        <ButtonLink href={`${WEBAPP_URL}${paths.webapp}`} style={{marginRight: 16}} data-uie-name={`${uieName}-webapp`}>
           {translate('openWithBrowser')}
         </ButtonLink>
       )}

--- a/src/script/page/ConversationJoin.tsx
+++ b/src/script/page/ConversationJoin.tsx
@@ -103,7 +103,10 @@ export const ConversationJoin: React.FC<ConversationJoinProps> = ({location}) =>
                     <OpenWireButtons
                       translate={(key, substitutes) => t(key, {...substitutes, ns: translationNamespaces})}
                       uieName="do-conversation-join"
-                      paths={{app: 'conversation-join/', webapp: '/join'}}
+                      paths={{
+                        app: pathWithParams('conversation-join/', {code, key}),
+                        webapp: pathWithParams('/join', {code, key}),
+                      }}
                     />
                   </FlexBox>
                 </>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes extra parameters that were added to all the generated urls since #3483 