### PR TITLE
fix: add hl param to url based on user's navigator

### DIFF
--- a/src/script/Root.tsx
+++ b/src/script/Root.tsx
@@ -20,7 +20,7 @@
 import {Global} from '@emotion/core';
 import {COLOR, FlexBox, Loading, StyledApp} from '@wireapp/react-ui-kit';
 import createBrowserHistory from 'history/createBrowserHistory';
-import React, {lazy, Suspense} from 'react';
+import React, {lazy, Suspense, useEffect} from 'react';
 import {Redirect, Route, Router, Switch} from 'react-router-dom';
 import {ROUTE} from 'script/route';
 
@@ -40,6 +40,18 @@ const Root: React.FC<Props> = () => {
   const LazyVerifyPhoneAccount = lazy(() => import('./page/VerifyPhoneAccount'));
   const LazyConversationJoin = lazy(() => import('./page/ConversationJoin'));
   const LazyUserProfile = lazy(() => import('./page/UserProfile'));
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(window.location.search);
+    const hlParam = queryParams.get('hl');
+
+    if (!hlParam || hlParam !== 'en') {
+      queryParams.set('hl', window.navigator.language);
+      window.history.pushState(null, '', `?${queryParams.toString()}`);
+      window.location.reload();
+    }
+  }, []);
+
   return (
     <StyledApp>
       <Global

--- a/src/script/Root.tsx
+++ b/src/script/Root.tsx
@@ -46,8 +46,8 @@ const Root: React.FC<Props> = () => {
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
     const hlParam = queryParams.get(LANG_QUERY_KEY);
-
     const userLocale = navigator.languages?.length ? navigator.languages[0] : navigator.language;
+
     if (!hlParam && !userLocale.includes('en')) {
       queryParams.set(LANG_QUERY_KEY, userLocale);
       window.history.pushState(null, '', `?${queryParams.toString()}`);

--- a/src/script/Root.tsx
+++ b/src/script/Root.tsx
@@ -45,8 +45,9 @@ const Root: React.FC<Props> = () => {
     const queryParams = new URLSearchParams(window.location.search);
     const hlParam = queryParams.get('hl');
 
-    if (!hlParam || hlParam !== 'en') {
-      queryParams.set('hl', window.navigator.language);
+    if (!hlParam) {
+      const userLocale = navigator.languages?.length ? navigator.languages[0] : navigator.language;
+      queryParams.set('hl', userLocale);
       window.history.pushState(null, '', `?${queryParams.toString()}`);
       window.location.reload();
     }

--- a/src/script/Root.tsx
+++ b/src/script/Root.tsx
@@ -23,12 +23,11 @@ import createBrowserHistory from 'history/createBrowserHistory';
 import React, {lazy, Suspense, useEffect} from 'react';
 import {Redirect, Route, Router, Switch} from 'react-router-dom';
 import {ROUTE} from 'script/route';
+import {QUERY_KEY} from './util/urlUtil';
 
 const history = createBrowserHistory();
 
 interface Props {}
-
-const LANG_QUERY_KEY = 'hl';
 
 const Root: React.FC<Props> = () => {
   const LazyIndex = lazy(() => import('./page/Index'));
@@ -45,11 +44,11 @@ const Root: React.FC<Props> = () => {
 
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
-    const hlParam = queryParams.get(LANG_QUERY_KEY);
+    const hlParam = queryParams.get(QUERY_KEY.LANG);
     const userLocale = navigator.languages?.length ? navigator.languages[0] : navigator.language;
 
     if (!hlParam && !userLocale.includes('en')) {
-      queryParams.set(LANG_QUERY_KEY, userLocale);
+      queryParams.set(QUERY_KEY.LANG, userLocale);
       window.history.pushState(null, '', `?${queryParams.toString()}`);
       window.location.reload();
     }

--- a/src/script/Root.tsx
+++ b/src/script/Root.tsx
@@ -28,6 +28,8 @@ const history = createBrowserHistory();
 
 interface Props {}
 
+const LANG_QUERY_KEY = 'hl';
+
 const Root: React.FC<Props> = () => {
   const LazyIndex = lazy(() => import('./page/Index'));
   const LazyDeleteAccount = lazy(() => import('./page/DeleteAccount'));
@@ -43,11 +45,11 @@ const Root: React.FC<Props> = () => {
 
   useEffect(() => {
     const queryParams = new URLSearchParams(window.location.search);
-    const hlParam = queryParams.get('hl');
+    const hlParam = queryParams.get(LANG_QUERY_KEY);
 
-    if (!hlParam) {
-      const userLocale = navigator.languages?.length ? navigator.languages[0] : navigator.language;
-      queryParams.set('hl', userLocale);
+    const userLocale = navigator.languages?.length ? navigator.languages[0] : navigator.language;
+    if (!hlParam && !userLocale.includes('en')) {
+      queryParams.set(LANG_QUERY_KEY, userLocale);
       window.history.pushState(null, '', `?${queryParams.toString()}`);
       window.location.reload();
     }

--- a/src/script/module/action/AccountAction.ts
+++ b/src/script/module/action/AccountAction.ts
@@ -19,7 +19,9 @@
 import {APIClient} from '@wireapp/api-client';
 
 export class AccountAction {
-  constructor(private readonly apiClient: APIClient) {
+  private readonly apiClient: APIClient;
+
+  constructor(apiClient: APIClient) {
     this.apiClient = apiClient;
   }
 

--- a/src/script/page/ConversationJoin.tsx
+++ b/src/script/page/ConversationJoin.tsx
@@ -99,7 +99,7 @@ export const ConversationJoin: React.FC<ConversationJoinProps> = ({location}) =>
               {hasDisplayedButtons() ? (
                 <>
                   <Text block>{t('description', {ns: translationNamespaces})}</Text>
-                  <FlexBox column={isMobile} css={{marginTop: 24}}>
+                  <FlexBox flexWrap="wrap" column={isMobile} css={{marginTop: 24}}>
                     <OpenWireButtons
                       translate={(key, substitutes) => t(key, {...substitutes, ns: translationNamespaces})}
                       uieName="do-conversation-join"

--- a/src/script/util/urlUtil.ts
+++ b/src/script/util/urlUtil.ts
@@ -30,6 +30,7 @@ export enum QUERY_KEY {
   LOGOUT_REASON = 'reason',
   PWA_AWARE = 'pwa_aware',
   TRACKING = 'tracking',
+  LANG = 'hl',
 }
 
 const FORWARDED_QUERY_KEYS = [QUERY_KEY.LOCALE, QUERY_KEY.TRACKING];


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add hl=(lang) param to url based on user's navigator preferences.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
