### PR TITLE
fix: Do not show conversation location for public wire

### DIFF
--- a/src/script/page/ConversationJoin.tsx
+++ b/src/script/page/ConversationJoin.tsx
@@ -97,9 +97,11 @@ export const ConversationJoin: React.FC<ConversationJoinProps> = ({location}) =>
               {hasDisplayedButtons() ? (
                 <>
                   <Text block>{t('description', {ns: translationNamespaces})}</Text>
-                  <Paragraph muted css={{marginTop: '8px'}}>
-                    {t('conversationLocation', {domain, ns: translationNamespaces})}
-                  </Paragraph>
+                  {IS_SELF_HOSTED && (
+                    <Paragraph muted css={{marginTop: '8px'}}>
+                      {t('conversationLocation', {domain, ns: translationNamespaces})}
+                    </Paragraph>
+                  )}
                   <Paragraph muted css={{marginTop: '8px'}}>
                     {t('wirelessHeadline', {brandName: BRAND_NAME, domain, ns: translationNamespaces})}
                   </Paragraph>


### PR DESCRIPTION
The `conversation takes place on <domain>` should only appear for self hosted instance of wire, not the public one