### PR TITLE
fix(actions): prevent command injection (WPB-9709)

### DIFF
--- a/.github/workflows/deploy-to-test-env.yml
+++ b/.github/workflows/deploy-to-test-env.yml
@@ -23,8 +23,10 @@ jobs:
     steps:
       - name: Print environment variables
         run: |
-          echo -e "branch = ${{github.ref_name}}"
-          echo -e "env = ${{inputs.env}}"
+          echo -e "branch = ${GITHUB_REF_NAME}"
+          echo -e "env = ${ENV}"
+        env:
+          ENV: ${{inputs.env}}
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -19,18 +19,18 @@ jobs:
         run: echo "CURRENT_TAG=$(git tag --points-at ${{github.sha}})" >> "$GITHUB_ENV"
 
       - name: 'Set previous Git tag'
-        run: echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude ${{env.CURRENT_TAG}})" >> "$GITHUB_ENV"
+        run: echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 --exclude ${CURRENT_TAG})" >> "$GITHUB_ENV"
 
       - name: 'Print environment variables'
         run: |
-          echo -e "PREVIOUS_TAG = ${{env.PREVIOUS_TAG}}"
-          echo -e "CURRENT_TAG = ${{env.CURRENT_TAG}}"
+          echo -e "PREVIOUS_TAG = ${PREVIOUS_TAG}"
+          echo -e "CURRENT_TAG = ${CURRENT_TAG}"
           echo -e "Node.js version = $(node --version)"
 
       - name: 'Generate changelog'
         run: |
           echo "{}" > ./package.json
-          npx generate-changelog@1.8.0 -t ${{env.PREVIOUS_TAG}}...${{env.CURRENT_TAG}}
+          npx generate-changelog@1.8.0 -t ${PREVIOUS_TAG}...${CURRENT_TAG}
 
       - name: 'Attach changelog to tag'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -173,10 +173,9 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CHARTS_WEBAPP_AUTOMATION_AWS_SECRET_ACCESS_KEY }}
+          DOCKER_IMAGE_TAG: ${{steps.push_docker_image.outputs.image_tag}}
         run: |
           set -eo pipefail
-
-          image_tag="${{steps.push_docker_image.outputs.image_tag}}"
 
           helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.15.1
 
@@ -189,7 +188,7 @@ jobs:
           fi
           echo "chart_version=$chart_version" >> $GITHUB_OUTPUT
 
-          chart_patched="$(yq -Mr ".version = \"$chart_version\" | .appVersion = \"$image_tag\"" ./charts/account-pages/Chart.yaml)"
+          chart_patched="$(yq -Mr ".version = \"$chart_version\" | .appVersion = \"${DOCKER_IMAGE_TAG}\"" ./charts/account-pages/Chart.yaml)"
           echo "$chart_patched" > ./charts/account-pages/Chart.yaml
 
           helm package ./charts/account-pages
@@ -229,6 +228,8 @@ jobs:
 
       - name: Create new build in wire-build
         shell: bash
+        env:
+          DOCKER_IMAGE_TAG: ${{needs.test_build_deploy.outputs.image_tag}}
         run: |
           set -eo pipefail
 
@@ -237,7 +238,6 @@ jobs:
           git config --global user.email "zebot@users.noreply.github.com"
           git config --global user.name "Zebot"
 
-          image_tag="${{needs.test_build_deploy.outputs.image_tag}}"
 
           for retry in $(seq 3); do
             set +e
@@ -256,7 +256,7 @@ jobs:
               ./bin/set-chart-fields account-pages \
               "version=$chart_version" \
               "repo=https://s3-eu-west-1.amazonaws.com/public.wire.com/charts-webapp" \
-              "meta.appVersion=$image_tag" \
+              "meta.appVersion=${DOCKER_IMAGE_TAG}" \
               "meta.commitURL=${{github.event.head_commit.url}}" \
               "meta.commit=${{github.event.head_commit.id}}" \
             | ./bin/bump-prerelease )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR fixes a potential command injection in the GitHub Actions workflow of this repository.
Unsanitized user input could be used to execute arbitrary code in the context of the workflow.

e.g.:
- specially crafted tags, e.g. `docker/v0.0.0;$(cat${IFS}/etc/passwd)#`,
- workflow inputs like `env`

### Solutions

Instead of using the unsanitized tag directly, it is passed to the run step as an environment variable. This prevents command execution like in the above example.

### Testing

#### How to Test
This change was tested with the workflow listed below in a separate repository by pushing tags in the shape of 'docker/v0.0.0;$(cat${IFS}/etc/passwd)#'.

Test0 resembles the original workflow of this repo, and Test1 is the fixed version.

An actual test can be made by pushing above tag to a repo with below workflow:
```
# Example workflow crafted to prove command injection through a crafted semver tag
on:
  push: {}
jobs:
  publish_all:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4.1.6
        with:
          fetch-depth: 0
      - name: Set tag output
        id: vars
        run: echo "tag=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT
      - name: Test0
        run: echo ${TAG}
        env:
          TAG: ${{ steps.vars.outputs.tag }}
      - name: Test1
        run: echo ${{ steps.vars.outputs.tag }}
```
### Notes (Optional)

Exploiting this requires knowledge of the workflow code, execution environment and, most importantly, tag push permission.

Note that git tags are quite restrictive in terms of which characters are allowed, so one cannot just paste a shell script, and that the tag push permission would usually imply that an attacker would already be able to directly modify workflow code.

Nevertheless, as a best practice, we shall try to sanitize any user input that is used in a run step.

----
#### PR Post Submission Checklist for internal contributors

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
   - Idk why auto linking doesn't work, but [WPB-9577](https://wearezeta.atlassian.net/browse/WPB-9577) is the related Jira issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

- https://wearezeta.atlassian.net/wiki/spaces/SC/pages/1216053328/How+to+avoid+Command+Injection+via+Github+Actions+or+CI+jobs+in+general
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack


[WPB-9577]: https://wearezeta.atlassian.net/browse/WPB-9577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ