### PR TITLE
runfix: put css-prop babel preset back

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -40,6 +40,7 @@ module.exports = {
   plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-syntax-dynamic-import'],
   presets: [
     ['@babel/preset-react', {runtime: 'automatic'}],
+    '@emotion/babel-preset-css-prop',
     '@babel/preset-typescript',
     [
       '@babel/preset-env',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "7.24.7",
     "@babel/preset-react": "7.24.7",
     "@babel/preset-typescript": "7.24.7",
+    "@emotion/babel-preset-css-prop": "11.11.0",
     "@testing-library/react": "12.1.4",
     "@types/jest": "27.5.0",
     "@types/node": "20.14.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,7 +1004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.24.7, @babel/plugin-syntax-jsx@npm:^7.7.2":
+"@babel/plugin-syntax-jsx@npm:^7.17.12, @babel/plugin-syntax-jsx@npm:^7.24.7, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.24.7
   resolution: "@babel/plugin-syntax-jsx@npm:7.24.7"
   dependencies:
@@ -1601,7 +1601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx@npm:^7.24.7":
+"@babel/plugin-transform-react-jsx@npm:^7.17.12, @babel/plugin-transform-react-jsx@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-react-jsx@npm:7.24.7"
   dependencies:
@@ -2114,6 +2114,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/babel-plugin-jsx-pragmatic@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@emotion/babel-plugin-jsx-pragmatic@npm:0.2.1"
+  dependencies:
+    "@babel/plugin-syntax-jsx": ^7.17.12
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 2c7e9c687c8e12855c9a419e9a8e530b236e1c42f5a196f1abaf5079947d18069733f1f8257e90c6bafa302c87f433577745ea799b63d4211c82d7b3a57917d6
+  languageName: node
+  linkType: hard
+
 "@emotion/babel-plugin@npm:^11.11.0":
   version: 11.11.0
   resolution: "@emotion/babel-plugin@npm:11.11.0"
@@ -2130,6 +2141,20 @@ __metadata:
     source-map: ^0.5.7
     stylis: 4.2.0
   checksum: 6b363edccc10290f7a23242c06f88e451b5feb2ab94152b18bb8883033db5934fb0e421e2d67d09907c13837c21218a3ac28c51707778a54d6cd3706c0c2f3f9
+  languageName: node
+  linkType: hard
+
+"@emotion/babel-preset-css-prop@npm:11.11.0":
+  version: 11.11.0
+  resolution: "@emotion/babel-preset-css-prop@npm:11.11.0"
+  dependencies:
+    "@babel/plugin-transform-react-jsx": ^7.17.12
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.11.0
+    "@emotion/babel-plugin-jsx-pragmatic": ^0.2.1
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: fcaddd107e2fb431cf22254e8a764d4e3308d1dab38611dc55d40a5e746f14b04aee0c12d349e3e0e4af1049d43efa52f8b8d5cc78167204159a40dffb7b4fde
   languageName: node
   linkType: hard
 
@@ -13667,6 +13692,7 @@ __metadata:
     "@babel/preset-env": 7.24.7
     "@babel/preset-react": 7.24.7
     "@babel/preset-typescript": 7.24.7
+    "@emotion/babel-preset-css-prop": 11.11.0
     "@testing-library/react": 12.1.4
     "@types/jest": 27.5.0
     "@types/node": 20.14.8


### PR DESCRIPTION
When updating packages, I've removed babel-preset-css-prop. It's needed when we overwrite ui-kit library's styles and want them to be extended instead of overwritten completely. It was causing issues like this:

See margin being applied, but all other styles are reset.
```jsx
 <ButtonLink href={`${WEBAPP_URL}/auth`} css={{marginTop: 40}} data-uie-name="do-go-back-to-login">
        {t('login')}
 </ButtonLink>
```

without preset:
<img width="793" alt="Screenshot 2024-06-24 at 13 22 34" src="https://github.com/wireapp/wire-account/assets/45733298/c23fcbf9-ddb7-44b3-bbbc-7eefdb09bdaa">


now, with preset:
<img width="671" alt="Screenshot 2024-06-24 at 13 22 16" src="https://github.com/wireapp/wire-account/assets/45733298/ff9ffec2-0f3e-4888-9694-232afb2eb2d2">


