### PR TITLE
fix: don't expose email already in use [WPB-9752]

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -19,10 +19,10 @@
     "errorAlreadyProcessing": "We already sent you an email. The link is valid for 1 hour.",
     "errorInvalidEmail": "That does not look like an email.",
     "errorUnknown": "Something went wrong, please try again.",
-    "errorUnusedEmail": "This email is not in use.",
     "successDescription": "We sent you a link to reset your password. It is valid for 1 hour.",
     "successTitle": "Check your email",
-    "title": "Change Password",
+    "title": "Reset password",
+    "description": "We will send you a link to reset your password via email.",
     "login": "Log in"
   },
   "general": {

--- a/src/script/page/PasswordForgot.tsx
+++ b/src/script/page/PasswordForgot.tsx
@@ -24,7 +24,6 @@ import Document from 'script/component/Document';
 import {ActionContext} from 'script/module/action';
 import ValidationError from 'script/module/action/ValidationError';
 
-const HTTP_STATUS_EMAIL_NOT_IN_USE = 400;
 const HTTP_STATUS_EMAIL_ALREADY_SENT = 409;
 
 const PasswordForgot = () => {

--- a/src/script/page/PasswordForgot.tsx
+++ b/src/script/page/PasswordForgot.tsx
@@ -65,10 +65,6 @@ const PasswordForgot = () => {
         }
       } else {
         switch (error.code) {
-          case HTTP_STATUS_EMAIL_NOT_IN_USE: {
-            setError(t('errorUnusedEmail'));
-            break;
-          }
           case HTTP_STATUS_EMAIL_ALREADY_SENT: {
             setError(t('errorAlreadyProcessing'));
             break;
@@ -95,7 +91,8 @@ const PasswordForgot = () => {
         ) : (
           <React.Fragment>
             <H1>{t('title')}</H1>
-            <Form onSubmit={initiatePasswordReset}>
+            <Text center>{t('description')}</Text>
+            <Form css={{marginTop: 40}} onSubmit={initiatePasswordReset}>
               <Input
                 required
                 ref={emailInput}


### PR DESCRIPTION
Removes "email not in use" error message when trying to reset password with an email that doesn't exist. For now it'll show generic "Something went wrong" error. After the request is handled properly on BE side (to always return 200 OK), it will always show the success screen, even for non-existing emails.

Before:
<img width="559" alt="Screenshot 2024-06-24 at 13 57 22" src="https://github.com/wireapp/wire-account/assets/45733298/c669e82e-0b98-4ed9-ad67-556a1495a6ca">


Now:
<img width="626" alt="Screenshot 2024-06-24 at 13 56 58" src="https://github.com/wireapp/wire-account/assets/45733298/b9df985b-3712-4cc2-93f6-ea13884b5012">

