### PR TITLE
runfix: order of babel presets to support react fragments

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -39,8 +39,8 @@ module.exports = {
   },
   plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-syntax-dynamic-import'],
   presets: [
-    ['@babel/preset-react', {runtime: 'automatic'}],
     '@emotion/babel-preset-css-prop',
+    ['@babel/preset-react', {importSource: '@emotion/react', runtime: 'automatic'}],
     '@babel/preset-typescript',
     [
       '@babel/preset-env',


### PR DESCRIPTION
`'@emotion/babel-preset-css-prop'` needs to be put before preset-react. In a previous config react fragments (`<></>`) were not supported without explicitly importing react.