### PR TITLE
chore: update node version (20) for test_build_deploy

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Set environment variables
         env:
           # DISTRIBUTIONS are saved in the format `distribution-{name}`


### PR DESCRIPTION
## Description:

Updated node version to 20 test_build_deploy GH action.

## References:
https://github.com/actions/runner-images/issues/7002
https://github.com/wireapp/wire-account/actions/runs/11037520154/job/30658572702