### PR TITLE
chore: map correct branch to wire-builds

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -69,20 +69,16 @@ jobs:
         id: output_target_branches
         with:
           key: '${{github.ref}}'
-          # TODO add production and staging once wire-builds has those branches
-          #
-          # "production": {
-          #  "targets": "[\"TDB\"]"
-          # },
-          # "staging": {
+          # TODO  Add staging if we ever use a wire-builds as a source for staging (we use k8s)
+          # "[TBD]": {
           #   "targets": "[\"TBD\"]"
           # },
           map: |
             {
-              "production": {
+              "release*": {
                "targets": "[\"main\"]"
               },
-              "dev": {
+              "staging": {
                 "targets": "[\"dev\"]"
               },
               "q1-2024": {

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           # },
           map: |
             {
-              "release*": {
+              "main": {
                "targets": "[\"main\"]"
               },
               "staging": {


### PR DESCRIPTION
### Description

The branch name and tags used to map the correct account release to wire-build was based on the name of webapp branches and does not correspond to the account repo.

### Changes

- map the `main` wire-account branch to the `main` wire-build branch (previously was mapping a `production` tag that doesn't exist on wire-account)
- map the `staging` wire-account branch to the `dev` wire-build branch (wira-account `staging` branch is used in dev environments and not with production backends)