### PR TITLE
chore: fix deployment race condition

### DIFF
--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -125,7 +125,7 @@ jobs:
           environment_name: wire-account-staging-node22
           region: eu-central-1
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
-          wait_for_deployment: false
+          wait_for_deployment: true
           wait_for_environment_recovery: ${{env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS}}
           version_label: ${{github.run_id}}
           version_description: ${{github.sha}}
@@ -140,7 +140,7 @@ jobs:
           environment_name: wire-account-prod-node22
           region: eu-central-1
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
-          wait_for_deployment: false
+          wait_for_deployment: true
           wait_for_environment_recovery: ${{env.DEPLOYMENT_RECOVERY_TIMEOUT_SECONDS}}
           version_label: ${{env.TAG}}-${{github.run_id}}
           version_description: ${{github.sha}}


### PR DESCRIPTION
node 22 environments need a bit longer time to start so we need to wait for deployment

Node.js 22 environments:
Have longer initialization or more strict validation
App version registration is asynchronous in AWS — it might not be “ready” when deployment starts

