### PR TITLE
(chore): Change pipeline to deploy to node22 environments

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -1,8 +1,8 @@
 branch-defaults:
   staging:
-    environment: wire-account-staging
+    environment: wire-account-staging-node22
   main:
-    environment: wire-account-prod
+    environment: wire-account-prod-node22
 deploy:
   artifact: wire-account.zip
 global:

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -122,7 +122,7 @@ jobs:
           aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
           aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
           application_name: ${{env.AWS_APPLICATION_NAME}}
-          environment_name: wire-account-staging
+          environment_name: wire-account-staging-node22
           region: eu-central-1
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
           wait_for_deployment: false
@@ -137,7 +137,7 @@ jobs:
           aws_access_key: ${{secrets.WEBTEAM_AWS_ACCESS_KEY_ID}}
           aws_secret_key: ${{secrets.WEBTEAM_AWS_SECRET_ACCESS_KEY}}
           application_name: ${{env.AWS_APPLICATION_NAME}}
-          environment_name: wire-account-prod
+          environment_name: wire-account-prod-node22
           region: eu-central-1
           deployment_package: ${{env.AWS_BUILD_ZIP_PATH}}
           wait_for_deployment: false

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you would like your browser to trust the certificate from "local.zinfra.io":
 
 Depending on the branch name it will be automatically deployed to the following environments:
 
-- `staging` -> `wire-account-staging`
+- `staging` -> `wire-account-staging-node22`
 
 ### Translations
 


### PR DESCRIPTION
**PR Summary**
Update Account app deployment to the new Node.js 22 Elastic Beanstalk environments

**What’s changed**
Point staging and main deploy steps at the *-node22 EB environments running Node 22