### PR TITLE
ci: remove gha-yarn-cache from github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
         with:
           access_token: ${{github.token}}
 
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
-
       - name: Authenticate git clone
         env:
           GH_TOKEN: ${{secrets.OTTO_THE_BOT_GH_TOKEN}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
 
       - name: Install JS dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/test_build_deploy.yml
+++ b/.github/workflows/test_build_deploy.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
 
       - name: Set environment variables
         env:
@@ -98,9 +99,6 @@ jobs:
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{github.token}}
-
-      - name: Yarn cache
-        uses: c-hive/gha-yarn-cache@v2.1.0
 
       - name: Authenticate git clone
         env:


### PR DESCRIPTION
### Description

- `gha-yarn-cache` is no longer supported